### PR TITLE
Generate selectable dates, don't hardcode them

### DIFF
--- a/project_template/forms.py
+++ b/project_template/forms.py
@@ -5,8 +5,10 @@ from project_template import constants
 from project_template.datamodels.real_estate_type import RealEstateType
 from project_template.datamodels.attainment_type import AttainmentType
 
-YEAR_CHOICES = ('2008', '2009', '2010', '2011', '2012', '2013', '2014', '2015', '2016', '2017', '2018', '2019')
-
+import datetime
+start_date = 2008
+end_date = datetime.datetime.now().year
+YEAR_CHOICES = tuple(map(str, range(start_date, end_date + 1)))
 
 class TranscribeInitialInformation(forms.Form):
     name = forms.CharField(label=_("What is the name of the current politician?"))


### PR DESCRIPTION
Because as time passes, we would like to add a possible
year every year, I changed the hardcoded list into a
function that gets the current year and generates all
possible years, thus making the design more future proof.