### PR TITLE
Add virtual environment instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Project-specific
 db.sqlite3
+venv/
 
 # IDE
 .idea/

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ This remains currently undecided.
 Installation process
 * Clone this repo: `git clone git@github.com:code4romania/catpol-declaratii.git`
 * Open the directory where you have cloned the repo (`cd catpol-declaratii`)
+* Create a virtual environment named "venv": `python3 -m venv venv`
+* Activate the virtual environment: `source venv/bin/activate`
 * `pip install -r requirements-dev.txt` 
 * `export DJANGO_SETTINGS_MODULE=project_template.settings.dev`
 * `python manage.py migrate`

--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ This remains currently undecided.
 Installation process
 * Clone this repo: `git clone git@github.com:code4romania/catpol-declaratii.git`
 * Open the directory where you have cloned the repo (`cd catpol-declaratii`)
-* Create a virtual environment named "venv": `python3 -m venv venv`
-* Activate the virtual environment: `source venv/bin/activate`
+* Optionally, you can create a virtual environment named "venv": `python3 -m venv venv` and then activate it: `source venv/bin/activate`
 * `pip install -r requirements-dev.txt` 
 * `export DJANGO_SETTINGS_MODULE=project_template.settings.dev`
 * `python manage.py migrate`


### PR DESCRIPTION
Added details to the Installation process on how to create and activate a Python3 virtual environment. A virtual environment is recommended so that project-specific libraries do not interfere with the system Python libraries (https://docs.python.org/3/tutorial/venv.html).