### PR TITLE
Data type enum refactor

### DIFF
--- a/project_template/datamodels/account_type.py
+++ b/project_template/datamodels/account_type.py
@@ -1,15 +1,8 @@
-from enum import Enum
+from project_template.datamodels import common_utils
 
 
-class AccountType(Enum):
+class AccountType(common_utils.IterableEnum):
     CURRENT_ACCOUNT = (1, "Cont curent sau echivalente (inclusiv card)")
     BANK_DEPOSIT = (2, "Depozit bancar sau echivalente")
     INVESTMENT_FUNDS = (3, "Fonduri de investitii sau echivalente, inclusiv fonduri private de pensii sau alte sisteme "
                             "cu acumulare (se vor declara cele aferente anului fiscal anterior)")
-
-    @staticmethod
-    def return_as_iterable():
-        enum_info_as_list = [member for name, member in AccountType.__members__.items()]
-        values = [member.value for member in enum_info_as_list]
-
-        return values

--- a/project_template/datamodels/attainment_type.py
+++ b/project_template/datamodels/attainment_type.py
@@ -1,8 +1,7 @@
-from enum import Enum
 from project_template.datamodels import common_utils
 
 
-class AttainmentType(Enum):
+class AttainmentType(common_utils.IterableEnum):
     PURCHASE = "Cumparare/Contract Vanzare Cumparare"
     CONSTRUCTION = "Construire"
     DONATION = "Donatie"
@@ -11,7 +10,3 @@ class AttainmentType(Enum):
     INHERITANCE = "Mostenire"
     LEASING = "Leasing"
     OTHER = "Alt mod"
-
-    @staticmethod
-    def return_as_iterable():
-        return common_utils.return_enum_as_iterable(AttainmentType)

--- a/project_template/datamodels/building_type.py
+++ b/project_template/datamodels/building_type.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from project_template.datamodels import common_utils
 
 
@@ -8,10 +7,3 @@ class BuildingType(common_utils.IterableEnum):
     VACATION_HOUSE = (3, "Casa de vacanta")
     COMMERCIAL_SPACE = (4, "Spatii comerciale")
     OTHER = (5, "Alta categorie")
-
-    # @staticmethod
-    # def return_as_iterable():
-    #     enum_info_as_list = [member for name, member in BuildingType.__members__.items()]
-    #     values = [member.value for member in enum_info_as_list]
-    #
-    #     return values

--- a/project_template/datamodels/building_type.py
+++ b/project_template/datamodels/building_type.py
@@ -1,16 +1,17 @@
 from enum import Enum
+from project_template.datamodels import common_utils
 
 
-class BuildingType(Enum):
+class BuildingType(common_utils.IterableEnum):
     APARTMENT = (1, "Apartament")
     HOUSE = (2, "Casa de locuit")
     VACATION_HOUSE = (3, "Casa de vacanta")
     COMMERCIAL_SPACE = (4, "Spatii comerciale")
     OTHER = (5, "Alta categorie")
 
-    @staticmethod
-    def return_as_iterable():
-        enum_info_as_list = [member for name, member in BuildingType.__members__.items()]
-        values = [member.value for member in enum_info_as_list]
-
-        return values
+    # @staticmethod
+    # def return_as_iterable():
+    #     enum_info_as_list = [member for name, member in BuildingType.__members__.items()]
+    #     values = [member.value for member in enum_info_as_list]
+    #
+    #     return values

--- a/project_template/datamodels/common_utils.py
+++ b/project_template/datamodels/common_utils.py
@@ -2,53 +2,25 @@ from enum import Enum
 
 
 class IterableEnum(Enum):
-
+    """
+    An Enum type which can return its members' values as an iterable
+    """
     @classmethod
     def return_as_iterable(cls):
-        items = cls.__members__.items()
-        member_values = [v for k, v in items]
-
-        print(member_values)
+        member_values = [v.value for k, v in cls.__members__.items()]
 
         if all(isinstance(x, tuple) for x in member_values):
+            # all Enum member values are tuples
             enum_info_as_list = [member for name, member in cls.__members__.items()]
-            # values = [(member.name, member.value) for member in enum_info_as_list]
             values = [member.value for member in enum_info_as_list]
+
+        elif any(isinstance(x, tuple) for x in member_values):
+            # the Enum member values are a mix of tuples and other types
+            raise TypeError
+
         else:
-            print(type(member_values[0]))
+            # all Enum member values are non-tuples
+            enum_info_as_list = [member for name, member in cls.__members__.items()]
+            values = [(member.name, member.value) for member in enum_info_as_list]
+
         return values
-
-    #
-    # @classmethod
-    # def return_as_iterable(cls):
-    #     return (1, 2, 3)
-    #     items = cls.__members__.items()
-    #     if all(isinstance(x, tuple) for x in items):
-    #         # all enum members are tuples
-    #         enum_info_as_list = [member for name, member in items]
-    #         values = [member.value for member in enum_info_as_list]
-    #     elif any(isinstance(x, str) for x in items):
-    #         # the enum members are a mix of tuples and other types
-    #         raise TypeError
-    #     else:
-    #         # all enum members are non-tuples
-    #         enum_info_as_list = [member for name, member in cls.__members__.items()]
-    #         values = [(member.name, member.value) for member in enum_info_as_list]
-    #     return values
-
-
-# Old stuff:
-
-def return_enum_as_iterable(self):
-    enum_info_as_list = [member for name, member in self.__members__.items()]
-    values = [(member.name, member.value) for member in enum_info_as_list]
-
-    return values
-
-
-def return_as_ordered_iterable(self):
-    enum_info_as_list = [member for name, member in self.__members__.items()]
-    values = [member.value for member in enum_info_as_list]
-
-    return values
-

--- a/project_template/datamodels/common_utils.py
+++ b/project_template/datamodels/common_utils.py
@@ -1,3 +1,44 @@
+from enum import Enum
+
+
+class IterableEnum(Enum):
+
+    @classmethod
+    def return_as_iterable(cls):
+        items = cls.__members__.items()
+        member_values = [v for k, v in items]
+
+        print(member_values)
+
+        if all(isinstance(x, tuple) for x in member_values):
+            enum_info_as_list = [member for name, member in cls.__members__.items()]
+            # values = [(member.name, member.value) for member in enum_info_as_list]
+            values = [member.value for member in enum_info_as_list]
+        else:
+            print(type(member_values[0]))
+        return values
+
+    #
+    # @classmethod
+    # def return_as_iterable(cls):
+    #     return (1, 2, 3)
+    #     items = cls.__members__.items()
+    #     if all(isinstance(x, tuple) for x in items):
+    #         # all enum members are tuples
+    #         enum_info_as_list = [member for name, member in items]
+    #         values = [member.value for member in enum_info_as_list]
+    #     elif any(isinstance(x, str) for x in items):
+    #         # the enum members are a mix of tuples and other types
+    #         raise TypeError
+    #     else:
+    #         # all enum members are non-tuples
+    #         enum_info_as_list = [member for name, member in cls.__members__.items()]
+    #         values = [(member.name, member.value) for member in enum_info_as_list]
+    #     return values
+
+
+# Old stuff:
+
 def return_enum_as_iterable(self):
     enum_info_as_list = [member for name, member in self.__members__.items()]
     values = [(member.name, member.value) for member in enum_info_as_list]

--- a/project_template/datamodels/currency.py
+++ b/project_template/datamodels/currency.py
@@ -1,8 +1,7 @@
-from enum import Enum
 from project_template.datamodels import common_utils
 
 
-class Currency(Enum):
+class Currency(common_utils.IterableEnum):
     EUR = "EUR"
     RON = "RON"
     USD = "USD"
@@ -10,7 +9,3 @@ class Currency(Enum):
     CAD = "CAD"
     CHF = "CHF"
     ALTELE = "OTHER"
-
-    @staticmethod
-    def return_as_iterable():
-        return common_utils.return_enum_as_iterable(Currency)

--- a/project_template/datamodels/debt_type.py
+++ b/project_template/datamodels/debt_type.py
@@ -1,14 +1,10 @@
-from enum import Enum
 from project_template.datamodels import common_utils
 
-class DebtType(Enum):
-    #valabila pentru situatia in care creditorul este persoana fizica (adaugat de Catalina)
+
+class DebtType(common_utils.IterableEnum):
+    # valabila pentru situatia in care creditorul este persoana fizica (adaugat de Catalina)
     IMPRUMUT = "IMPRUMUT"
     DEBIT = "DEBIT"
     MORTGAGE = "IPOTECA"
     ISSUED_GARANTIES = "GARANTII EMISE"
     LEASING_ACQUIRED_GOODS = "BUNURI ACHIZIONATE LEASING"
-
-    @staticmethod
-    def return_as_iterable():
-        return common_utils.return_enum_as_iterable(DebtType)

--- a/project_template/datamodels/declaration_type.py
+++ b/project_template/datamodels/declaration_type.py
@@ -1,10 +1,6 @@
-from enum import Enum
 from project_template.datamodels import common_utils
 
-class DeclarationType(Enum):
+
+class DeclarationType(common_utils.IterableEnum):
     ASSET = "Declaratie de avere"
     INTEREST = "Declaratie de interes"
-
-    @staticmethod
-    def return_as_iterable():
-        return common_utils.return_enum_as_iterable(DeclarationType)

--- a/project_template/datamodels/estranged_goods_type.py
+++ b/project_template/datamodels/estranged_goods_type.py
@@ -1,8 +1,7 @@
-from enum import Enum
 from project_template.datamodels import common_utils
 
 
-class EstrangedGoodsType(Enum):
+class EstrangedGoodsType(common_utils.IterableEnum):
     APARTMENT = "Apartament"
     HOUSE = "Casa de locuit"
     VACATION_HOUSE = "Casa de vacanta"
@@ -12,7 +11,3 @@ class EstrangedGoodsType(Enum):
     AGRICULTURAL_VEHICLE = "Masini agricole"
     BOATS = "Salupe"
     YACHTS = "Iahturi"
-
-    @staticmethod
-    def return_as_iterable():
-        return common_utils.return_enum_as_iterable(EstrangedGoodsType)

--- a/project_template/datamodels/financial_institution.py
+++ b/project_template/datamodels/financial_institution.py
@@ -1,8 +1,7 @@
-from enum import Enum
-from project_template.datamodels import  common_utils
+from project_template.datamodels import common_utils
 
 
-class FinancialInstitution(Enum):
+class FinancialInstitution(common_utils.IterableEnum):
 
     ALPHA_BANK = "ALPHA BANK"
     BCR = "BANCA COMERCIALĂ ROMÂNĂ (OF THE ERSTE GROUP)"
@@ -31,9 +30,3 @@ class FinancialInstitution(Enum):
     EXIMBANK = "EXIMBANK (EXPORT-IMPORT BANK OF ROMANIA)"
     ING = "ING BANK N.V. (OF ING GROUP)"
     PARIBAS = "BNP PARIBAS PERSONAL FINANCE"
-
-    @staticmethod
-    def return_as_iterable():
-        return common_utils.return_enum_as_iterable(FinancialInstitution)
-
-

--- a/project_template/datamodels/goods_separation_type.py
+++ b/project_template/datamodels/goods_separation_type.py
@@ -1,14 +1,9 @@
-from enum import Enum
 from project_template.datamodels import common_utils
 
 
-class GoodsSeparationType(Enum):
+class GoodsSeparationType(common_utils.IterableEnum):
     SELL = "Vanzare"
     SEPARATION = "Partaj"
     DONATION = "Donatie"
     ARBITRATION = "Executare"
     OTHER = "Alta forma"
-
-    @staticmethod
-    def return_as_iterable():
-        return common_utils.return_enum_as_iterable(GoodsSeparationType)

--- a/project_template/datamodels/holder_relationship.py
+++ b/project_template/datamodels/holder_relationship.py
@@ -1,13 +1,7 @@
-from enum import Enum
-
 from project_template.datamodels import common_utils
 
 
-class HolderRelationship(Enum):
+class HolderRelationship(common_utils.IterableEnum):
     HOLDER = "TITULAR"
     SPOUSE = "SOT/SOTIE"
     CHILDREN = "COPII"
-
-    @staticmethod
-    def return_as_iterable():
-        return common_utils.return_enum_as_iterable(HolderRelationship)

--- a/project_template/datamodels/holder_type.py
+++ b/project_template/datamodels/holder_type.py
@@ -1,11 +1,6 @@
-from enum import Enum
 from project_template.datamodels import common_utils
 
 
-class HolderType(Enum):
+class HolderType(common_utils.IterableEnum):
     INSTITUTION = "Institutie"
     PERSON = "Persoana"
-
-    @staticmethod
-    def return_as_iterable():
-        return common_utils.return_enum_as_iterable(HolderType)

--- a/project_template/datamodels/income_provider_type.py
+++ b/project_template/datamodels/income_provider_type.py
@@ -1,13 +1,7 @@
-from enum import Enum
 from project_template.datamodels import common_utils
 
 
-class IncomeProviderType(Enum):
+class IncomeProviderType(common_utils.IterableEnum):
     HOLDER = "Titular"
     SPOUSE = "Sot/sotie"
     KIDS = "Copii"
-
-    @staticmethod
-    def return_as_iterable():
-        return common_utils.return_enum_as_iterable(IncomeProviderType)
-

--- a/project_template/datamodels/institution.py
+++ b/project_template/datamodels/institution.py
@@ -1,8 +1,7 @@
-from enum import Enum
-
 from project_template.datamodels import common_utils
 
-class Institution(Enum):
+
+class Institution(common_utils.IterableEnum):
     GOVERNMENT = "Guvernul Romaniei"
     PARLIAMENT = "Parlamentul Romaniei "
     SENATE = "Senat"
@@ -33,7 +32,3 @@ class Institution(Enum):
     EVERYWHERE_MINISTRY = "Ministerul pentru Romanii de Pretutindeni"
     PARLIAMENT_MINISTRY = "Ministerul pentru Relatia cu Parlamentul"
     OTHER = "Alta Valoare"
-
-    @staticmethod
-    def return_as_iterable():
-        return common_utils.return_enum_as_iterable(Institution)

--- a/project_template/datamodels/investment_type.py
+++ b/project_template/datamodels/investment_type.py
@@ -1,12 +1,7 @@
-from enum import Enum
 from project_template.datamodels import common_utils
 
 
-class InvestmentType(Enum):
+class InvestmentType(common_utils.IterableEnum):
     VALUE_PAPERS = "HARTII DE VALOARE"
     SHARES = "ACTIUNI/PARTI SOCIALE"
     PERSONAL_LOANS = "IMPRUMUTURI ACORDATE IN NUME PERSONAL"
-
-    @staticmethod
-    def return_as_iterable():
-        return common_utils.return_enum_as_iterable(InvestmentType)

--- a/project_template/datamodels/mobile_goods_type.py
+++ b/project_template/datamodels/mobile_goods_type.py
@@ -1,15 +1,10 @@
-from enum import Enum
 from project_template.datamodels import common_utils
 
 
-class MobileGoodsType(Enum):
+class MobileGoodsType(common_utils.IterableEnum):
     AUTOVEHICLE = "Autovehicule/Autoturisme"
     TRACTOR = "Tractor"
     AGRICULTURAL_VEHICLE = "Masini agricole"
     BOATS = "Salupe"
     YACHTS = "Iahturi"
     OTHER = "Altele"
-
-    @staticmethod
-    def return_as_iterable():
-        return common_utils.return_enum_as_iterable(MobileGoodsType)

--- a/project_template/datamodels/position.py
+++ b/project_template/datamodels/position.py
@@ -1,8 +1,7 @@
-from enum import Enum
-
 from project_template.datamodels import common_utils
 
-class Position(Enum):
+
+class Position(common_utils.IterableEnum):
     GENERAL_SECRETARY = "Secretar General"
     DEPUTY = "Deputat"
     SENATOR = "Senator"
@@ -16,9 +15,3 @@ class Position(Enum):
     COUNSELOR = "Consilier"
     STATE_SECRETARY = "Secretar de Stat"
     OTHER = "Alta Valoare"
-
-    @staticmethod
-    def return_as_iterable():
-        return common_utils.return_enum_as_iterable(Position)
-
-

--- a/project_template/datamodels/real_estate_type.py
+++ b/project_template/datamodels/real_estate_type.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from project_template.datamodels import common_utils
 
 
@@ -8,7 +7,3 @@ class RealEstateType(common_utils.IterableEnum):
     URBAN = "Intravilan"
     LAKE = "Lucia de apa"
     OTHER = "Alte categorii"
-
-    @classmethod
-    def return_as_iterable(cls):
-        return common_utils.return_enum_as_iterable(cls)

--- a/project_template/datamodels/real_estate_type.py
+++ b/project_template/datamodels/real_estate_type.py
@@ -2,13 +2,13 @@ from enum import Enum
 from project_template.datamodels import common_utils
 
 
-class RealEstateType(Enum):
+class RealEstateType(common_utils.IterableEnum):
     AGRICULTURAL = "Agricol"
     FOREST = "Forestier"
     URBAN = "Intravilan"
     LAKE = "Lucia de apa"
     OTHER = "Alte categorii"
 
-    @staticmethod
-    def return_as_iterable():
-        return common_utils.return_enum_as_iterable(RealEstateType)
+    @classmethod
+    def return_as_iterable(cls):
+        return common_utils.return_enum_as_iterable(cls)

--- a/project_template/tasks.py
+++ b/project_template/tasks.py
@@ -478,6 +478,7 @@ class TaskOwnedBuildingsRowEntry(DigitalizationTask):
         )
 
 
+@register()
 class TaskOwnedBuildingsTable(CountTableRowsTask):
     task_form = forms.TranscribeOwnedBuildingsTable
     storage_model = models.OwnedBuildingsTable
@@ -507,7 +508,7 @@ class TaskOwnedIncomeFromInvestmentsRowEntry(DigitalizationTask):
         )
 
 
-@register()
+
 class TaskOwnedIncomeFromInvestmentsTable(CountTableRowsTask):
     task_form = forms.TranscribeOwnedIncomeFromInvestmentsTable
     storage_model = models.OwnedIncomeFromInvestmentsTable


### PR DESCRIPTION
Remove duplication from the various project `datamodels` by moving the common `return_as_iterable` method to a custom subclass of `Enum` named `IterableEnum`

The `IterableEnum` handles the two Enum types I've encountered in the projects: the ones with tuple member values, like:
```python
class BuildingType(common_utils.IterableEnum):
    APARTMENT = (1, "Apartament")
    HOUSE = (2, "Casa de locuit")
    VACATION_HOUSE = (3, "Casa de vacanta")
    COMMERCIAL_SPACE = (4, "Spatii comerciale")
    OTHER = (5, "Alta categorie")
```
and the ones with string or number member values, like:
```python
class DeclarationType(common_utils.IterableEnum):
    ASSET = "Declaratie de avere"
    INTEREST = "Declaratie de interes"
```
It will raise a `TypeError` if you try to mix tuples and plain text values in the same enumeration. 
(We could handle that case too if it's needed, but I don't see a reason for mixing the two)