### PR TITLE
Add Dockerfile for catpol solution and docker compose for pybossa dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /opt/catpol
 COPY ./requirements* /opt/catpol/
 RUN pip3 install -r requirements-dev.txt
 COPY . /opt/catpol
-ENV DJANGO_SETTINGS_MODULE=project_template.settings.dev
+ENV DJANGO_SETTINGS_MODULE=project_template.settings.production
 RUN python3 manage.py migrate 
 CMD python3 manage.py runserver 0.0.0.0:8000
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.5.7-alpine3.10
+RUN apk add git
+WORKDIR /opt/catpol
+COPY ./requirements* /opt/catpol/
+RUN pip3 install -r requirements-dev.txt
+COPY . /opt/catpol
+ENV DJANGO_SETTINGS_MODULE=project_template.settings.dev
+RUN python3 manage.py migrate 
+CMD python3 manage.py runserver 0.0.0.0:8000
+EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Using Dockerfile:
 * Run the following command to create a Docker image for the project `docker build -t catpol`
 * Run the following command to run the Docker image `docker run -p 8000 catpol`
 * Show the container id running the `catpol` image `docker ps`
-* Inspect the container to get the host port `docker inspect <container_id>`, you should something like:
-            ```json
+* Inspect the container to get the host port `docker inspect <container_id>`, you should see something like:
+```json
             "Ports": {
                 "8000/tcp": [
                     {
@@ -109,7 +109,7 @@ Using Dockerfile:
                     }
                 ]
             },
-            ```
+ ```
  * Connect to specified port on localhost and enjoy the solution
 
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,27 @@ Installation process
 * `python manage.py migrate`
 * `python manage.py runserver`
 
+Using Dockerfile:
+* Install docker
+* Clone this repo: `git clone git@github.com:code4romania/catpol-declaratii.git`
+* Open the directory where you have cloned the repo (`cd catpol-declaratii`)
+* Run the following command to create a Docker image for the project `docker build -t catpol`
+* Run the following command to run the Docker image `docker run -p 8000 catpol`
+* Show the container id running the `catpol` image `docker ps`
+* Inspect the container to get the host port `docker inspect <container_id>`, you should something like:
+            ```json
+            "Ports": {
+                "8000/tcp": [
+                    {
+                        "HostIp": "0.0.0.0",
+                        "HostPort": "32769"
+                    }
+                ]
+            },
+            ```
+ * Connect to specified port on localhost and enjoy the solution
+
+
 ## Contributing 
 
 If you would like to contribute to one of our repositories, first identify the scale of what you would like to contribute. If it is small (grammar/spelling or a bug fix) feel free to start working on a fix. If you are submitting a feature or substantial code contribution, please discuss it with the team and ensure it follows the product roadmap. 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,58 @@
+version: "2"
+services:
+    catpol:
+      build: .
+      depends_on:
+        - postgres
+        - pybossa
+      ports:
+        - "8000:8000"
+    redis-master:
+        image: 'redis:3.0-alpine'
+    redis-sentinel:
+        image: 'jvstein/redis-sentinel:latest'
+        depends_on:
+            - redis-master
+        links:
+            - redis-master
+    postgres:
+        image: 'postgres:9.6-alpine'
+        environment:
+            - POSTGRES_USER=$DB_USER
+            - POSTGRES_PASSWORD=$DB_PASSWORD
+    # initializes the database
+    db-init:
+        image: 'jvstein/pybossa:latest'
+        depends_on:
+            - postgres
+        environment:
+            - POSTGRES_URL=postgresql://$DB_USER:$DB_PASSWORD@db/pybossa
+        links:
+            - postgres:db
+        command: sh -c "sleep 5 && python cli.py db_create"
+    # background worker process
+    pybossa-bgworker:
+        image: 'jvstein/pybossa:latest'
+        depends_on:
+            - db-init
+        environment:
+            - POSTGRES_URL=postgresql://$DB_USER:$DB_PASSWORD@db/pybossa
+        links:
+            - redis-master
+            - redis-sentinel
+            - postgres:db
+        command: rqscheduler --host redis-master
+    # web server
+    pybossa:
+        image: 'jvstein/pybossa:latest'
+        container_name: pybossa
+        depends_on:
+            - db-init
+        environment:
+            - POSTGRES_URL=postgresql://$DB_USER:$DB_PASSWORD@db/pybossa
+        links:
+            - redis-master
+            - redis-sentinel
+            - postgres:db
+        ports:
+            - "8080:8080"


### PR DESCRIPTION
Add Dockerfile for catpol solution.
Now the server can be built as a docker image and run as a container.
Also the pybossa server dependency can be deployed as a docker container using the docker-compose in the pull request.